### PR TITLE
Add makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ CC := cc
 CCFLAGS := -lX11 -lXft -Os
 LDFLAGS := `pkg-config --cflags freetype2`
 DEBUGFLAGS := -fsanitize=undefined -fsanitize=address -fno-sanitize-recover
-DEPS := menu.c menu.h
+DEPS := menu.c menu.h config.h
 TARGETS := menu
 
 all: $(TARGETS)

--- a/makefile
+++ b/makefile
@@ -1,0 +1,21 @@
+CC := cc
+CCFLAGS := -lX11 -lXft -Os
+LDFLAGS := `pkg-config --cflags freetype2`
+DEBUGFLAGS := -fsanitize=undefined -fsanitize=address -fno-sanitize-recover
+DEPS := menu.c menu.h
+TARGETS := menu
+
+all: $(TARGETS)
+
+debug: $(DEPS)
+	@echo 'compiling with debug flags...'
+	@$(CC) $< $(CCFLAGS) $(LDFLAGS) $(DEBUGFLAGS) -o $(TARGETS)
+	@echo 'done.'
+
+clean:
+	rm -f $(TARGETS)
+
+$(TARGETS): $(DEPS)
+	@echo 'compiling...'
+	@$(CC) $< $(CCFLAGS) $(LDFLAGS) -o $@
+	@echo 'done.'


### PR DESCRIPTION
Adds makefile to project.

## Usage

run `make` with no arguments to compile normally. Optionally run `make debug` to include debugging flags to compilation. You may also run `make clean` to remove the executable generated by the previous 2 commands.